### PR TITLE
Implement Pagination component and App state management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,30 @@
-import React from 'react';
+import React, { useState } from 'react';
 import './App.css';
 import { getNumbers } from './utils';
+import { Pagination } from './components/Pagination';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const items = getNumbers(1, 42).map(n => `Item ${n}`);
+const allItems = getNumbers(1, 42).map(n => `Item ${n}`);
 
 export const App: React.FC = () => {
+  const [currentPage, setCurrentPage] = useState(1);
+  const [perPage, setPerPage] = useState(5);
+
+  const total = allItems.length;
+  const firstItem = (currentPage - 1) * perPage + 1;
+  const lastItem = Math.min(currentPage * perPage, total);
+  const currentItems = allItems.slice(firstItem - 1, lastItem);
+
+  const handlePerPageChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setPerPage(Number(e.target.value));
+    setCurrentPage(1);
+  };
+
   return (
     <div className="container">
       <h1>Items with Pagination</h1>
 
       <p className="lead" data-cy="info">
-        Page 1 (items 1 - 5 of 42)
+        {`Page ${currentPage} (items ${firstItem} - ${lastItem} of ${total})`}
       </p>
 
       <div className="form-group row">
@@ -19,7 +32,10 @@ export const App: React.FC = () => {
           <select
             data-cy="perPageSelector"
             id="perPageSelector"
-            className="form-control">
+            className="form-control"
+            value={perPage}
+            onChange={handlePerPageChange}
+          >
             <option value="3">3</option>
             <option value="5">5</option>
             <option value="10">10</option>
@@ -32,78 +48,19 @@ export const App: React.FC = () => {
         </label>
       </div>
 
-      {/* Move this markup to Pagination */}
-      <ul className="pagination">
-        <li className="page-item disabled">
-          <a
-            data-cy="prevLink"
-            className="page-link"
-            href="#prev"
-            aria-disabled="true">
-            «
-          </a>
-        </li>
-        <li className="page-item active">
-          <a data-cy="pageLink" className="page-link" href="#1">
-            1
-          </a>
-        </li>
-        <li className="page-item">
-          <a data-cy="pageLink" className="page-link" href="#2">
-            2
-          </a>
-        </li>
-        <li className="page-item">
-          <a data-cy="pageLink" className="page-link" href="#3">
-            3
-          </a>
-        </li>
-        <li className="page-item">
-          <a data-cy="pageLink" className="page-link" href="#4">
-            4
-          </a>
-        </li>
-        <li className="page-item">
-          <a data-cy="pageLink" className="page-link" href="#5">
-            5
-          </a>
-        </li>
-        <li className="page-item">
-          <a data-cy="pageLink" className="page-link" href="#6">
-            6
-          </a>
-        </li>
-        <li className="page-item">
-          <a data-cy="pageLink" className="page-link" href="#7">
-            7
-          </a>
-        </li>
-        <li className="page-item">
-          <a data-cy="pageLink" className="page-link" href="#8">
-            8
-          </a>
-        </li>
-        <li className="page-item">
-          <a data-cy="pageLink" className="page-link" href="#9">
-            9
-          </a>
-        </li>
-        <li className="page-item">
-          <a
-            data-cy="nextLink"
-            className="page-link"
-            href="#next"
-            aria-disabled="false">
-            »
-          </a>
-        </li>
-      </ul>
+      <Pagination
+        total={total}
+        perPage={perPage}
+        currentPage={currentPage}
+        onPageChange={setCurrentPage}
+      />
+
       <ul>
-        <li data-cy="item">Item 1</li>
-        <li data-cy="item">Item 2</li>
-        <li data-cy="item">Item 3</li>
-        <li data-cy="item">Item 4</li>
-        <li data-cy="item">Item 5</li>
+        {currentItems.map(item => (
+          <li key={item} data-cy="item">
+            {item}
+          </li>
+        ))}
       </ul>
     </div>
   );

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,1 +1,80 @@
-export const Pagination = () => {};
+import React from 'react';
+import { getNumbers } from '../../utils';
+
+type Props = {
+  total: number;
+  perPage: number;
+  currentPage?: number;
+  onPageChange: (page: number) => void;
+};
+
+export const Pagination: React.FC<Props> = ({
+  total,
+  perPage,
+  currentPage = 1,
+  onPageChange,
+}) => {
+  const pageCount = Math.ceil(total / perPage);
+  const pages = getNumbers(1, pageCount);
+  const isFirst = currentPage === 1;
+  const isLast = currentPage === pageCount;
+
+  return (
+    <ul className="pagination">
+      <li className={`page-item${isFirst ? ' disabled' : ''}`}>
+        <a
+          data-cy="prevLink"
+          className="page-link"
+          href="#prev"
+          aria-disabled={isFirst ? 'true' : 'false'}
+          onClick={e => {
+            e.preventDefault();
+            if (!isFirst) {
+              onPageChange(currentPage - 1);
+            }
+          }}
+        >
+          «
+        </a>
+      </li>
+
+      {pages.map(page => (
+        <li
+          key={page}
+          className={`page-item${page === currentPage ? ' active' : ''}`}
+        >
+          <a
+            data-cy="pageLink"
+            className="page-link"
+            href={`#${page}`}
+            onClick={e => {
+              e.preventDefault();
+              if (page !== currentPage) {
+                onPageChange(page);
+              }
+            }}
+          >
+            {page}
+          </a>
+        </li>
+      ))}
+
+      <li className={`page-item${isLast ? ' disabled' : ''}`}>
+        <a
+          data-cy="nextLink"
+          className="page-link"
+          href="#next"
+          aria-disabled={isLast ? 'true' : 'false'}
+          onClick={e => {
+            e.preventDefault();
+            if (!isLast) {
+              onPageChange(currentPage + 1);
+            }
+          }}
+        >
+          »
+        </a>
+      </li>
+    </ul>
+  );
+};


### PR DESCRIPTION
Created stateless Pagination component with props: total, perPage, currentPage (default: 1), onPageChange
Renders page links with data-cy="pageLink", highlights active page with li.active
« / » prev/next links: disabled on first/last page via li.disabled and aria-disabled="true"
onPageChange triggers only when the page actually changes
App saves current page state and listens to onPageChange
Pagination info shows in format: Page 1 (items 1 - 5 of 42)
<select data-cy="perPageSelector"> with options 3, 5, 10, 20 — resets to page 1 on change
Items list renders only items for the current page

DEMO LINK
https://sonik-boom71.github.io/react_pagination/